### PR TITLE
Corrección de restauración en ventana de configuración

### DIFF
--- a/Sobreclick.csproj
+++ b/Sobreclick.csproj
@@ -16,10 +16,17 @@
     <PublishUrl>publish\</PublishUrl>
     <Install>true</Install>
     <InstallFrom>Disk</InstallFrom>
+    <UpdateEnabled>false</UpdateEnabled>
+    <UpdateMode>Foreground</UpdateMode>
+    <UpdateInterval>7</UpdateInterval>
+    <UpdateIntervalUnits>Days</UpdateIntervalUnits>
+    <UpdatePeriodically>false</UpdatePeriodically>
+    <UpdateRequired>false</UpdateRequired>
     <MapFileExtensions>true</MapFileExtensions>
     <ApplicationRevision>0</ApplicationRevision>
     <ApplicationVersion>1.0.0.%2a</ApplicationVersion>
     <UseApplicationTrust>false</UseApplicationTrust>
+    <BootstrapperEnabled>true</BootstrapperEnabled>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">
     <PlatformTarget>x86</PlatformTarget>

--- a/sc_config.Designer.cs
+++ b/sc_config.Designer.cs
@@ -42,7 +42,7 @@
             this.groupBox2 = new System.Windows.Forms.GroupBox();
             this.cbSonidosSistema = new System.Windows.Forms.CheckBox();
             this.btnReproducir = new System.Windows.Forms.Button();
-            this.textBox4 = new System.Windows.Forms.TextBox();
+            this.tbSoundDir = new System.Windows.Forms.TextBox();
             this.btnExmnr = new System.Windows.Forms.Button();
             this.groupBox1.SuspendLayout();
             this.groupBox2.SuspendLayout();
@@ -123,7 +123,7 @@
             // 
             this.groupBox2.Controls.Add(this.cbSonidosSistema);
             this.groupBox2.Controls.Add(this.btnReproducir);
-            this.groupBox2.Controls.Add(this.textBox4);
+            this.groupBox2.Controls.Add(this.tbSoundDir);
             this.groupBox2.Controls.Add(this.btnExmnr);
             resources.ApplyResources(this.groupBox2, "groupBox2");
             this.groupBox2.Name = "groupBox2";
@@ -143,10 +143,10 @@
             this.btnReproducir.UseVisualStyleBackColor = true;
             this.btnReproducir.Click += new System.EventHandler(this.button4_Click);
             // 
-            // textBox4
+            // tbSoundDir
             // 
-            resources.ApplyResources(this.textBox4, "textBox4");
-            this.textBox4.Name = "textBox4";
+            resources.ApplyResources(this.tbSoundDir, "tbSoundDir");
+            this.tbSoundDir.Name = "tbSoundDir";
             // 
             // btnExmnr
             // 
@@ -193,7 +193,7 @@
         private System.Windows.Forms.GroupBox groupBox2;
         private System.Windows.Forms.CheckBox cbSonidosSistema;
         private System.Windows.Forms.Button btnReproducir;
-        private System.Windows.Forms.TextBox textBox4;
+        private System.Windows.Forms.TextBox tbSoundDir;
         private System.Windows.Forms.Button btnExmnr;
     }
 }

--- a/sc_config.cs
+++ b/sc_config.cs
@@ -62,7 +62,7 @@ namespace Sobreclick
 
         private void button1_Click(object sender, EventArgs e)
         {
-            sonConfDir = textBox4.Text;
+            sonConfDir = tbSoundDir.Text;
             if (iniT == pauT || iniT == detT || detT == pauT)
             {
                 MessageBox.Show(rm.GetString("msgEqual"), "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
@@ -121,7 +121,7 @@ namespace Sobreclick
             tbIni.Clear();
             tbPR.Clear();
             pbDen.Clear();
-            textBox4.Clear();
+            tbSoundDir.Clear();
 
             // Cargar variables de teclas
             iniT = (Keys)conversor.ConvertFromString(Conf.teclaIniciar());
@@ -131,11 +131,12 @@ namespace Sobreclick
             tbIni.AppendText(iniT.ToString() + "\r\n");
             tbPR.AppendText(pauT.ToString() + "\r\n");
             pbDen.AppendText(detT.ToString() + "\r\n");
-            textBox4.AppendText(sonConfDir + "\r\n");
+            tbSoundDir.AppendText(sonConfDir + "\r\n");
             if (sonConfDir == "")
             {
                 turnarConfigSonido();
             }
+            this.tbSoundDir.TextChanged += new System.EventHandler(this.tbSoundDir_TextChanged);
         }
 
         private void turnarConfigSonido()
@@ -143,13 +144,13 @@ namespace Sobreclick
             switch (sonSistemaPreferido)
             {
                 case true:
-                    textBox4.Enabled = true;
+                    tbSoundDir.Enabled = true;
                     btnExmnr.Enabled = true;
                     sonSistemaPreferido = false;
                     break;
                 case false:
                 default:
-                    textBox4.Enabled = false;
+                    tbSoundDir.Enabled = false;
                     btnExmnr.Enabled = false;
                     sonSistemaPreferido = true;
                     break;
@@ -166,6 +167,8 @@ namespace Sobreclick
             tbPR.AppendText(pauT.ToString() + "\r\n");
             pbDen.Clear();
             pbDen.AppendText(detT.ToString() + "\r\n");
+            tbSoundDir.Clear();
+            tbSoundDir.AppendText(sonConfDir + "\r\n");
             btnRestaurar.Enabled = false;
         }
 
@@ -182,7 +185,7 @@ namespace Sobreclick
                 if (cargarSon.ShowDialog() == DialogResult.OK && cargarSon.FileName.EndsWith(".wav"))
                 {
                     var fs = cargarSon.OpenFile();
-                    textBox4.Text = cargarSon.FileName;
+                    tbSoundDir.Text = cargarSon.FileName;
                 }
                 else
                 {
@@ -193,7 +196,7 @@ namespace Sobreclick
 
         private void button4_Click(object sender, EventArgs e)
         {
-            sonConfDir = textBox4.Text;
+            sonConfDir = tbSoundDir.Text;
 
             switch (sonSistemaPreferido)
             {
@@ -221,6 +224,11 @@ namespace Sobreclick
                 testingSound.Stop();
             }
             this.Dispose();
+        }
+
+        private void tbSoundDir_TextChanged(object sender, EventArgs e)
+        {
+            btnRestaurar.Enabled = true;
         }
     }
 }

--- a/sc_config.resx
+++ b/sc_config.resx
@@ -444,25 +444,25 @@
   <data name="&gt;&gt;btnReproducir.ZOrder" xml:space="preserve">
     <value>1</value>
   </data>
-  <data name="textBox4.Location" type="System.Drawing.Point, System.Drawing">
+  <data name="tbSoundDir.Location" type="System.Drawing.Point, System.Drawing">
     <value>9, 47</value>
   </data>
-  <data name="textBox4.Size" type="System.Drawing.Size, System.Drawing">
+  <data name="tbSoundDir.Size" type="System.Drawing.Size, System.Drawing">
     <value>205, 20</value>
   </data>
-  <data name="textBox4.TabIndex" type="System.Int32, mscorlib">
+  <data name="tbSoundDir.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
   </data>
-  <data name="&gt;&gt;textBox4.Name" xml:space="preserve">
-    <value>textBox4</value>
+  <data name="&gt;&gt;tbSoundDir.Name" xml:space="preserve">
+    <value>tbSoundDir</value>
   </data>
-  <data name="&gt;&gt;textBox4.Type" xml:space="preserve">
+  <data name="&gt;&gt;tbSoundDir.Type" xml:space="preserve">
     <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;textBox4.Parent" xml:space="preserve">
+  <data name="&gt;&gt;tbSoundDir.Parent" xml:space="preserve">
     <value>groupBox2</value>
   </data>
-  <data name="&gt;&gt;textBox4.ZOrder" xml:space="preserve">
+  <data name="&gt;&gt;tbSoundDir.ZOrder" xml:space="preserve">
     <value>2</value>
   </data>
   <data name="btnExmnr.Location" type="System.Drawing.Point, System.Drawing">
@@ -5586,16 +5586,16 @@
   <data name="&gt;&gt;$this.Type" xml:space="preserve">
     <value>System.Windows.Forms.Form, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-    <data name="msgEqual" xml:space="preserve">
+  <data name="msgEqual" xml:space="preserve">
     <value>Algunas teclas están repetidas. Revísalas y vuelve a intentarlo.</value>
   </data>
-	<data name="msgErrorSaving" xml:space="preserve">
+  <data name="msgErrorSaving" xml:space="preserve">
     <value>Error inesperado al guardar el archivo de configuración. Revisa que tengas lo permisos adecuados y vuelve a intentarlo.</value>
   </data>
-	<data name="msgSonDefault" xml:space="preserve">
+  <data name="msgSonDefault" xml:space="preserve">
     <value>No has seleccionado un archivo de sonido. ¿Deseas usar el del sistema?</value>
   </data>
-	<data name="msgErrorLoadingSound" xml:space="preserve">
+  <data name="msgErrorLoadingSound" xml:space="preserve">
     <value>El archivo especificado no es válido</value>
   </data>
 </root>


### PR DESCRIPTION
- En caso de modificarse el parámetro que contiene el directorio de sonido, se rehabilitará el botón de restaurar.
- Agregado de funciones de limpieza correspondientes para la anterior funcionalidad.
- Se renombra el campo de texto con el dato relevante.