### PR TITLE
 Opción "Salir" no ejecuta resto de tareas programadas

### DIFF
--- a/sobreclick.Designer.cs
+++ b/sobreclick.Designer.cs
@@ -68,6 +68,7 @@
             this.statusSC = new System.Windows.Forms.StatusStrip();
             this.statusText = new System.Windows.Forms.ToolStripStatusLabel();
             this.timerStatus = new System.Windows.Forms.Timer(this.components);
+            this.timerExit = new System.Windows.Forms.Timer(this.components);
             this.menuStrip1.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.numericUpDown1)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.numericUpDown2)).BeginInit();
@@ -367,6 +368,10 @@
             this.timerStatus.Interval = 5000;
             this.timerStatus.Tick += new System.EventHandler(this.timerStatus_Tick);
             // 
+            // timerExit
+            // 
+            this.timerExit.Tick += new System.EventHandler(this.timerExit_Tick_1);
+            // 
             // sobreclick
             // 
             resources.ApplyResources(this, "$this");
@@ -443,6 +448,7 @@
         private System.Windows.Forms.ToolStripStatusLabel statusText;
         private System.Windows.Forms.ToolStripMenuItem restaurarValoresToolStripMenuItem1;
         private System.Windows.Forms.ToolStripMenuItem masToolStripMenuItem;
+        private System.Windows.Forms.Timer timerExit;
     }
 }
 

--- a/sobreclick.cs
+++ b/sobreclick.cs
@@ -28,6 +28,7 @@ namespace Sobreclick
         public static bool salirAT = false;
         public static bool ejecutarScriptAT = false;
         public static bool restaurarValoresAT = false;
+        public static bool notificarAT = false;
 
         public ProcessStartInfo shutdownProcess = new ProcessStartInfo("shutdown", "-s -t 0");
 
@@ -309,7 +310,15 @@ namespace Sobreclick
             }
             if (salirAT)
             {
-                this.Dispose();
+                if (!notificarAT && !ejecutarScriptAT && !apagarAT)
+                {
+                    this.Close();
+                }
+                else
+                {
+                    timerExit.Enabled = true;
+                    timerExit.Start();
+                }
             }
             if (restaurarValoresAT)
             {
@@ -748,6 +757,11 @@ namespace Sobreclick
         {
             statusText.Text = "";
             timerStatus.Stop();
+        }
+
+        private void timerExit_Tick_1(object sender, EventArgs e)
+        {
+            this.Close();
         }
     }
 }

--- a/sobreclick.resx
+++ b/sobreclick.resx
@@ -122,6 +122,30 @@
     <value>17, 17</value>
   </data>
   <assembly alias="mscorlib" name="mscorlib, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <data name="menuStrip1.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="menuStrip1.Text" xml:space="preserve">
+    <value>menuStrip1</value>
+  </data>
+  <data name="&gt;&gt;menuStrip1.Name" xml:space="preserve">
+    <value>menuStrip1</value>
+  </data>
+  <data name="&gt;&gt;menuStrip1.Type" xml:space="preserve">
+    <value>System.Windows.Forms.MenuStrip, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;menuStrip1.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;menuStrip1.ZOrder" xml:space="preserve">
+    <value>14</value>
+  </data>
+  <data name="sobreclickToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
+    <value>73, 20</value>
+  </data>
+  <data name="sobreclickToolStripMenuItem.Text" xml:space="preserve">
+    <value>&amp;Sobreclick</value>
+  </data>
   <data name="restaurarValoresToolStripMenuItem.Enabled" type="System.Boolean, mscorlib">
     <value>False</value>
   </data>
@@ -139,6 +163,12 @@
   </data>
   <data name="toolStripSeparator1.Size" type="System.Drawing.Size, System.Drawing">
     <value>161, 6</value>
+  </data>
+  <data name="cerrarAlTerminarToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
+    <value>163, 22</value>
+  </data>
+  <data name="cerrarAlTerminarToolStripMenuItem.Text" xml:space="preserve">
+    <value>&amp;Al terminar...</value>
   </data>
   <data name="salirToolStripMenuItem1.Size" type="System.Drawing.Size, System.Drawing">
     <value>213, 22</value>
@@ -182,11 +212,11 @@
   <data name="salirToolStripMenuItem.Text" xml:space="preserve">
     <value>&amp;Salir</value>
   </data>
-  <data name="sobreclickToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
-    <value>73, 20</value>
+  <data name="ventanaToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
+    <value>61, 20</value>
   </data>
-  <data name="sobreclickToolStripMenuItem.Text" xml:space="preserve">
-    <value>&amp;Sobreclick</value>
+  <data name="ventanaToolStripMenuItem.Text" xml:space="preserve">
+    <value>&amp;Ventana</value>
   </data>
   <data name="siempreVisibleToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
     <value>167, 22</value>
@@ -203,11 +233,11 @@
   <data name="restaurarTamañoToolStripMenuItem.Text" xml:space="preserve">
     <value>&amp;Restaurar tamaño</value>
   </data>
-  <data name="ventanaToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
-    <value>61, 20</value>
+  <data name="ayudaToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
+    <value>53, 20</value>
   </data>
-  <data name="ventanaToolStripMenuItem.Text" xml:space="preserve">
-    <value>&amp;Ventana</value>
+  <data name="ayudaToolStripMenuItem.Text" xml:space="preserve">
+    <value>&amp;Ayuda</value>
   </data>
   <data name="licenciaToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
     <value>183, 22</value>
@@ -229,36 +259,6 @@
   </data>
   <data name="ascercaToolStripMenuItem.Text" xml:space="preserve">
     <value>&amp;Acerca de Sobreclick</value>
-  </data>
-  <data name="ayudaToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
-    <value>53, 20</value>
-  </data>
-  <data name="ayudaToolStripMenuItem.Text" xml:space="preserve">
-    <value>&amp;Ayuda</value>
-  </data>
-  <data name="menuStrip1.Location" type="System.Drawing.Point, System.Drawing">
-    <value>0, 0</value>
-  </data>
-  <data name="menuStrip1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>269, 24</value>
-  </data>
-  <data name="menuStrip1.TabIndex" type="System.Int32, mscorlib">
-    <value>0</value>
-  </data>
-  <data name="menuStrip1.Text" xml:space="preserve">
-    <value>menuStrip1</value>
-  </data>
-  <data name="&gt;&gt;menuStrip1.Name" xml:space="preserve">
-    <value>menuStrip1</value>
-  </data>
-  <data name="&gt;&gt;menuStrip1.Type" xml:space="preserve">
-    <value>System.Windows.Forms.MenuStrip, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;menuStrip1.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="&gt;&gt;menuStrip1.ZOrder" xml:space="preserve">
-    <value>14</value>
   </data>
   <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="buttonC.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">


### PR DESCRIPTION
- Nuevo timer con delay, para darle tiempo a Sobreclick a ejecutar el programa preestablecido en la opción "Al terminar...". Solo funcionará si alguna de las funciones conflictivas están activas.