### PR TITLE
Archivo especificado no válido

### DIFF
--- a/sc_config.Designer.cs
+++ b/sc_config.Designer.cs
@@ -153,7 +153,7 @@
             resources.ApplyResources(this.btnExmnr, "btnExmnr");
             this.btnExmnr.Name = "btnExmnr";
             this.btnExmnr.UseVisualStyleBackColor = true;
-            this.btnExmnr.Click += new System.EventHandler(this.button3_Click);
+            this.btnExmnr.Click += new System.EventHandler(this.btnExmnr_Click);
             // 
             // sc_config
             // 

--- a/sc_config.cs
+++ b/sc_config.cs
@@ -156,6 +156,27 @@ namespace Sobreclick
                     break;
             }
         }
+
+        public void cargarArchivoSonido()
+        {
+            using (OpenFileDialog cargarSon = new OpenFileDialog())
+            {
+                cargarSon.Filter = "WaveForm Audio Format (*.wav)|*.wav";
+                DialogResult resultadoCarga = cargarSon.ShowDialog();
+                if (resultadoCarga == DialogResult.OK && cargarSon.FileName.EndsWith(".wav"))
+                {
+                    if (cargarSon.FileName.EndsWith(".wav"))
+                    {
+                        var fs = cargarSon.OpenFile();
+                        tbSoundDir.Text = cargarSon.FileName;
+                    }
+                    else
+                    {
+                        MessageBox.Show(rm.GetString("msgErrorLoadingSound"), "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                    }
+                }
+            }
+        }
         private void button2_Click(object sender, EventArgs e)
         {
             iniT = strings.iniT;
@@ -177,21 +198,9 @@ namespace Sobreclick
             turnarConfigSonido();
         }
 
-        private void button3_Click(object sender, EventArgs e)
+        private void btnExmnr_Click(object sender, EventArgs e)
         {
-            using (OpenFileDialog cargarSon = new OpenFileDialog())
-            {
-                cargarSon.Filter = "WaveForm Audio Format (*.wav)|*.wav";
-                if (cargarSon.ShowDialog() == DialogResult.OK && cargarSon.FileName.EndsWith(".wav"))
-                {
-                    var fs = cargarSon.OpenFile();
-                    tbSoundDir.Text = cargarSon.FileName;
-                }
-                else
-                {
-                    MessageBox.Show(rm.GetString("msgErrorLoadingSound"), "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
-                }
-            }
+            cargarArchivoSonido();
         }
 
         private void button4_Click(object sender, EventArgs e)


### PR DESCRIPTION
- Se crea una nueva función para la carga de archivo de sonido, en lugar de llamarla directamente desde la acción.
- Reimplementación del resultado de la carga. Si no da Aceptar, no hace nada.
- Se separa la detección del nombre de archivo con la del DialogResult.