### PR TITLE
Parsear automáticamente la barra a barra invertida

### DIFF
--- a/conf.cs
+++ b/conf.cs
@@ -28,7 +28,7 @@ namespace Sobreclick
         }
         public string dirSonido()
         {
-            return ConfigurationManager.AppSettings.Get("dirSonido");
+            return ConfigurationManager.AppSettings.Get("dirSonido").Replace("/", "\\");
         }
     }
 }

--- a/sc_config.Designer.cs
+++ b/sc_config.Designer.cs
@@ -141,7 +141,7 @@
             resources.ApplyResources(this.btnReproducir, "btnReproducir");
             this.btnReproducir.Name = "btnReproducir";
             this.btnReproducir.UseVisualStyleBackColor = true;
-            this.btnReproducir.Click += new System.EventHandler(this.button4_Click);
+            this.btnReproducir.Click += new System.EventHandler(this.btnReproducir_Click);
             // 
             // tbSoundDir
             // 

--- a/sc_config.cs
+++ b/sc_config.cs
@@ -203,9 +203,9 @@ namespace Sobreclick
             cargarArchivoSonido();
         }
 
-        private void button4_Click(object sender, EventArgs e)
+        private void btnReproducir_Click(object sender, EventArgs e)
         {
-            sonConfDir = tbSoundDir.Text;
+            sonConfDir = tbSoundDir.Text.Replace("/", "\\");
 
             switch (sonSistemaPreferido)
             {


### PR DESCRIPTION
* Si la variable de configuración relacionada al directorio de sonido contiene una o varias barras comunes "/", automáticamente las transforma a invertidas.
* Cambio de nombre en la función accionada por el botón de Reproducir; tenía el nombre predeterminado de WinForms.