### PR TITLE
Mejoras en configuración

### DIFF
--- a/sc_config.Designer.cs
+++ b/sc_config.Designer.cs
@@ -44,6 +44,7 @@
             this.btnReproducir = new System.Windows.Forms.Button();
             this.tbSoundDir = new System.Windows.Forms.TextBox();
             this.btnExmnr = new System.Windows.Forms.Button();
+            this.btnCancelar = new System.Windows.Forms.Button();
             this.groupBox1.SuspendLayout();
             this.groupBox2.SuspendLayout();
             this.SuspendLayout();
@@ -155,10 +156,18 @@
             this.btnExmnr.UseVisualStyleBackColor = true;
             this.btnExmnr.Click += new System.EventHandler(this.btnExmnr_Click);
             // 
+            // btnCancelar
+            // 
+            resources.ApplyResources(this.btnCancelar, "btnCancelar");
+            this.btnCancelar.Name = "btnCancelar";
+            this.btnCancelar.UseVisualStyleBackColor = true;
+            this.btnCancelar.Click += new System.EventHandler(this.btnCancelar_Click);
+            // 
             // sc_config
             // 
             resources.ApplyResources(this, "$this");
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.Controls.Add(this.btnCancelar);
             this.Controls.Add(this.groupBox2);
             this.Controls.Add(this.panel1);
             this.Controls.Add(this.btnRestaurar);
@@ -195,5 +204,6 @@
         private System.Windows.Forms.Button btnReproducir;
         private System.Windows.Forms.TextBox tbSoundDir;
         private System.Windows.Forms.Button btnExmnr;
+        private System.Windows.Forms.Button btnCancelar;
     }
 }

--- a/sc_config.cs
+++ b/sc_config.cs
@@ -239,5 +239,10 @@ namespace Sobreclick
         {
             btnRestaurar.Enabled = true;
         }
+
+        private void btnCancelar_Click(object sender, EventArgs e)
+        {
+            Close();
+        }
     }
 }

--- a/sc_config.resx
+++ b/sc_config.resx
@@ -123,7 +123,7 @@
   </data>
   <assembly alias="System.Drawing" name="System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
   <data name="btnGuardar.Location" type="System.Drawing.Point, System.Drawing">
-    <value>305, 213</value>
+    <value>224, 213</value>
   </data>
   <data name="btnGuardar.Size" type="System.Drawing.Size, System.Drawing">
     <value>75, 23</value>
@@ -145,7 +145,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;btnGuardar.ZOrder" xml:space="preserve">
-    <value>3</value>
+    <value>4</value>
   </data>
   <data name="tbIni.Location" type="System.Drawing.Point, System.Drawing">
     <value>98, 33</value>
@@ -340,7 +340,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;btnRestaurar.ZOrder" xml:space="preserve">
-    <value>2</value>
+    <value>3</value>
   </data>
   <data name="panel1.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
     <value>Top</value>
@@ -364,7 +364,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;panel1.ZOrder" xml:space="preserve">
-    <value>1</value>
+    <value>2</value>
   </data>
   <data name="groupBox1.Location" type="System.Drawing.Point, System.Drawing">
     <value>12, 30</value>
@@ -388,7 +388,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;groupBox1.ZOrder" xml:space="preserve">
-    <value>4</value>
+    <value>5</value>
   </data>
   <data name="cbSonidosSistema.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -511,6 +511,33 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;groupBox2.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="btnCancelar.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="btnCancelar.Location" type="System.Drawing.Point, System.Drawing">
+    <value>301, 213</value>
+  </data>
+  <data name="btnCancelar.Size" type="System.Drawing.Size, System.Drawing">
+    <value>75, 23</value>
+  </data>
+  <data name="btnCancelar.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="btnCancelar.Text" xml:space="preserve">
+    <value>&amp;Cancelar</value>
+  </data>
+  <data name="&gt;&gt;btnCancelar.Name" xml:space="preserve">
+    <value>btnCancelar</value>
+  </data>
+  <data name="&gt;&gt;btnCancelar.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;btnCancelar.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;btnCancelar.ZOrder" xml:space="preserve">
     <value>0</value>
   </data>
   <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
@@ -5585,17 +5612,5 @@
   </data>
   <data name="&gt;&gt;$this.Type" xml:space="preserve">
     <value>System.Windows.Forms.Form, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="msgEqual" xml:space="preserve">
-    <value>Algunas teclas están repetidas. Revísalas y vuelve a intentarlo.</value>
-  </data>
-  <data name="msgErrorSaving" xml:space="preserve">
-    <value>Error inesperado al guardar el archivo de configuración. Revisa que tengas lo permisos adecuados y vuelve a intentarlo.</value>
-  </data>
-  <data name="msgSonDefault" xml:space="preserve">
-    <value>No has seleccionado un archivo de sonido. ¿Deseas usar el del sistema?</value>
-  </data>
-  <data name="msgErrorLoadingSound" xml:space="preserve">
-    <value>El archivo especificado no es válido</value>
   </data>
 </root>

--- a/sobreclick.cs
+++ b/sobreclick.cs
@@ -34,6 +34,8 @@ namespace Sobreclick
 
         public static ResourceManager rm = new ResourceManager(typeof(sobreclick));
 
+        private sc_config ventana_configuracion = null;
+
         private const int MOUSEEVENTF_LEFTDOWN = 0X0002;
         private const int MOUSEEVENTF_LEFTUP = 0X0004;
         private const int MOUSEEVENTF_MIDDLEDOWN = 0X0020;
@@ -667,14 +669,18 @@ namespace Sobreclick
 
         private void configuraciónToolStripMenuItem_Click(object sender, EventArgs e)
         {
-            sc_config scC = new sc_config();
-            scC.Show();
-            scC.FormClosed += new FormClosedEventHandler(scC_FormClosed);
+            if (ventana_configuracion == null)
+            {
+                ventana_configuracion = new sc_config();
+                ventana_configuracion.FormClosed += sc_config_FormClosed;
+                ventana_configuracion.Show();
+            }
         }
 
-        private void scC_FormClosed(object sender, FormClosedEventArgs e)
+        private void sc_config_FormClosed(object sender, FormClosedEventArgs e)
         {
             actualizarTeclas();
+            ventana_configuracion = null;
         }
 
         private void sobreclick_FormClosing(object sender, FormClosingEventArgs e)


### PR DESCRIPTION
- Nuevo botón de cancelar en el form de configuración. Permite deshacer la operación actual, y no guardar ningún cambio.
- Creación de variable que contiene la ventana de ajustes. Se establece por defecto como null, y se implementa el objeto del susedicho form al momento de solicitar su apertura. Esto permite que no se reestablezca, a través de una condición.
- Botón de guardado movido, para dar espacio a la nueva opción.