### PR TITLE
Opción "Sonidos del sistema" no queda fija

### DIFF
--- a/conf.cs
+++ b/conf.cs
@@ -26,6 +26,12 @@ namespace Sobreclick
         {
             return ConfigurationManager.AppSettings.Get("detener");
         }
+        public bool sonidoPredeterminado()
+        {
+            bool valor_predeterminado = false;
+            bool.TryParse(ConfigurationManager.AppSettings.Get("sonidoPredeterminado"), out valor_predeterminado);
+            return valor_predeterminado;
+        }
         public string dirSonido()
         {
             return ConfigurationManager.AppSettings.Get("dirSonido").Replace("/", "\\");

--- a/sc_config.cs
+++ b/sc_config.cs
@@ -28,7 +28,7 @@ namespace Sobreclick
 
         // Sonidos
         public static string sonConfDir = Conf.dirSonido();
-        public static bool sonSistemaPreferido = false;
+        public static bool sonSistemaPreferido = Conf.sonidoPredeterminado();
 
         public sc_config()
         {
@@ -108,6 +108,21 @@ namespace Sobreclick
                 {
                     strings.actualizarArchivoSon(@"C:\Windows\Media\chord.wav");
                 }
+                switch (sonSistemaPreferido)
+                {
+                    case true:
+                        cbSonidosSistema.Checked = true;
+                        tbSoundDir.Enabled = false;
+                        btnExmnr.Enabled = false;
+                        break;
+                    case false:
+                    default:
+                        cbSonidosSistema.Checked = false;
+                        tbSoundDir.Enabled = true;
+                        btnExmnr.Enabled = true;
+                        break;
+                }
+                strings.actualizarSonidoPredeterminado(sonSistemaPreferido);
                 this.Close();
             }
             catch (Exception E)
@@ -122,7 +137,7 @@ namespace Sobreclick
             tbPR.Clear();
             pbDen.Clear();
             tbSoundDir.Clear();
-
+            
             // Cargar variables de teclas
             iniT = (Keys)conversor.ConvertFromString(Conf.teclaIniciar());
             pauT = (Keys)conversor.ConvertFromString(Conf.teclaPausarReanudar());
@@ -132,11 +147,29 @@ namespace Sobreclick
             tbPR.AppendText(pauT.ToString() + "\r\n");
             pbDen.AppendText(detT.ToString() + "\r\n");
             tbSoundDir.AppendText(sonConfDir + "\r\n");
-            if (sonConfDir == "")
-            {
-                turnarConfigSonido();
-            }
             this.tbSoundDir.TextChanged += new System.EventHandler(this.tbSoundDir_TextChanged);
+
+            // Hacer detección de archivo de configuración
+            verificarConfSonido();
+        }
+
+        private void verificarConfSonido()
+        {
+            switch (sonSistemaPreferido)
+            {
+                case true:
+                    cbSonidosSistema.Checked = true;
+                    tbSoundDir.Enabled = true;
+                    btnExmnr.Enabled = true;
+                    cbSonidosSistema.Checked = true;
+                    break;
+                case false:
+                default:
+                    cbSonidosSistema.Checked = false;
+                    tbSoundDir.Enabled = false;
+                    btnExmnr.Enabled = false;
+                    break;
+            } 
         }
 
         private void turnarConfigSonido()
@@ -144,14 +177,16 @@ namespace Sobreclick
             switch (sonSistemaPreferido)
             {
                 case true:
-                    tbSoundDir.Enabled = true;
-                    btnExmnr.Enabled = true;
+                    cbSonidosSistema.Checked = false;
+                    tbSoundDir.Enabled = false;
+                    btnExmnr.Enabled = false;
                     sonSistemaPreferido = false;
                     break;
                 case false:
                 default:
-                    tbSoundDir.Enabled = false;
-                    btnExmnr.Enabled = false;
+                    cbSonidosSistema.Checked = true;
+                    tbSoundDir.Enabled = true;
+                    btnExmnr.Enabled = true;
                     sonSistemaPreferido = true;
                     break;
             }
@@ -210,10 +245,10 @@ namespace Sobreclick
             switch (sonSistemaPreferido)
             {
                 case true:
-                    testingSound = new SoundPlayer(@"C:\Windows\Media\chord.wav");
+                    testingSound = new SoundPlayer(sonConfDir);
                     break;
                 case false:
-                    testingSound = new SoundPlayer(sonConfDir);
+                    testingSound = new SoundPlayer(@"C:\Windows\Media\chord.wav");
                     break;
             }
             try

--- a/strings.cs
+++ b/strings.cs
@@ -66,6 +66,39 @@ namespace Sobreclick
             ConfigurationManager.RefreshSection(configSave.AppSettings.SectionInformation.Name);
         }
 
+        public static void actualizarSonidoPredeterminado(bool valor)
+        {
+            Configuration configSave = ConfigurationManager.OpenExeConfiguration(ConfigurationUserLevel.None);
+            switch (valor)
+            {
+                case true:
+                    configSave.AppSettings.Settings["sonidoPredeterminado"].Value = "true";
+                    break;
+                case false:
+                    configSave.AppSettings.Settings["sonidoPredeterminado"].Value = "false";
+                    break;
+            }
+            configSave.Save(ConfigurationSaveMode.Modified);
+            ConfigurationManager.RefreshSection(configSave.AppSettings.SectionInformation.Name);
+        }
+
+        public static void alternarSonidoPredeterminado()
+        {
+            Configuration configSave = ConfigurationManager.OpenExeConfiguration(ConfigurationUserLevel.None);
+            string valorConfigSonidoPred = configSave.AppSettings.Settings["sonidoPredeterminado"].Value.ToLower();
+            switch (valorConfigSonidoPred)
+            {
+                case "true":
+                    configSave.AppSettings.Settings["sonidoPredeterminado"].Value = "false";
+                    break;
+                case "false":
+                    configSave.AppSettings.Settings["sonidoPredeterminado"].Value = "true";
+                    break;
+            }
+            configSave.Save(ConfigurationSaveMode.Modified);
+            ConfigurationManager.RefreshSection(configSave.AppSettings.SectionInformation.Name);
+        }
+
         public bool abrirScript(string dir, string args)
         {
             ProcessWindowStyle wst = ProcessWindowStyle.Normal;


### PR DESCRIPTION
* Se crea las funciones actualizarSonidoPredeterminado y alternarSonidoPredeterminado. Ambas revisan y modifican el dato de la configuración relacionado a si se usará el sonido por defecto, al terminar una secuencia de clics.
* Modificación en la detección del anterior dato.