### PR TITLE
Error al guardar la configuración

### DIFF
--- a/sc_config.cs
+++ b/sc_config.cs
@@ -17,7 +17,7 @@ namespace Sobreclick
         static conf Conf = new conf();
         public static TypeConverter conversor = TypeDescriptor.GetConverter(typeof(Keys));
         SoundPlayer testingSound;
-
+        bool confInicialComprobada = false;
 
         ResourceManager rm = new ResourceManager(typeof(sc_config));
 
@@ -100,26 +100,15 @@ namespace Sobreclick
                 strings.actualizarTecla(1, iniT);
                 strings.actualizarTecla(2, pauT);
                 strings.actualizarTecla(3, detT);
-                if (!cbSonidosSistema.Checked)
-                {
-                    strings.actualizarArchivoSon(sonConfDir);
-                }
-                else
-                {
-                    strings.actualizarArchivoSon(@"C:\Windows\Media\chord.wav");
-                }
-                switch (sonSistemaPreferido)
+                strings.actualizarArchivoSon(sonConfDir);
+                switch (cbSonidosSistema.Checked)
                 {
                     case true:
-                        cbSonidosSistema.Checked = true;
-                        tbSoundDir.Enabled = false;
-                        btnExmnr.Enabled = false;
+                        sonSistemaPreferido = true;
                         break;
                     case false:
                     default:
-                        cbSonidosSistema.Checked = false;
-                        tbSoundDir.Enabled = true;
-                        btnExmnr.Enabled = true;
+                        sonSistemaPreferido = false;
                         break;
                 }
                 strings.actualizarSonidoPredeterminado(sonSistemaPreferido);
@@ -151,6 +140,8 @@ namespace Sobreclick
 
             // Hacer detección de archivo de configuración
             verificarConfSonido();
+
+            confInicialComprobada = true;
         }
 
         private void verificarConfSonido()
@@ -158,16 +149,15 @@ namespace Sobreclick
             switch (sonSistemaPreferido)
             {
                 case true:
-                    cbSonidosSistema.Checked = true;
-                    tbSoundDir.Enabled = true;
-                    btnExmnr.Enabled = true;
+                    tbSoundDir.Enabled = false;
+                    btnExmnr.Enabled = false;
                     cbSonidosSistema.Checked = true;
                     break;
                 case false:
                 default:
+                    tbSoundDir.Enabled = true;
+                    btnExmnr.Enabled = true;
                     cbSonidosSistema.Checked = false;
-                    tbSoundDir.Enabled = false;
-                    btnExmnr.Enabled = false;
                     break;
             } 
         }
@@ -178,15 +168,15 @@ namespace Sobreclick
             {
                 case true:
                     cbSonidosSistema.Checked = false;
-                    tbSoundDir.Enabled = false;
-                    btnExmnr.Enabled = false;
+                    tbSoundDir.Enabled = true;
+                    btnExmnr.Enabled = true;
                     sonSistemaPreferido = false;
                     break;
                 case false:
                 default:
                     cbSonidosSistema.Checked = true;
-                    tbSoundDir.Enabled = true;
-                    btnExmnr.Enabled = true;
+                    tbSoundDir.Enabled = false;
+                    btnExmnr.Enabled = false;
                     sonSistemaPreferido = true;
                     break;
             }
@@ -230,7 +220,16 @@ namespace Sobreclick
 
         private void checkBox1_CheckedChanged(object sender, EventArgs e)
         {
-            turnarConfigSonido();
+            switch (confInicialComprobada)
+            {
+                case true:
+                    turnarConfigSonido();
+                    break;
+                case false:
+                default:
+                    confInicialComprobada = true;
+                    break;
+            }
         }
 
         private void btnExmnr_Click(object sender, EventArgs e)
@@ -245,10 +244,11 @@ namespace Sobreclick
             switch (sonSistemaPreferido)
             {
                 case true:
-                    testingSound = new SoundPlayer(sonConfDir);
+                    // TODO: Parametrizar sonido predeterminado
+                    testingSound = new SoundPlayer(@"C:\Windows\Media\chord.wav");
                     break;
                 case false:
-                    testingSound = new SoundPlayer(@"C:\Windows\Media\chord.wav");
+                    testingSound = new SoundPlayer(sonConfDir);
                     break;
             }
             try

--- a/sc_config.resx
+++ b/sc_config.resx
@@ -112,23 +112,23 @@
     <value>2.0</value>
   </resheader>
   <resheader name="reader">
-    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <resheader name="writer">
-    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="btnGuardar.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Bottom, Right</value>
   </data>
-  <assembly alias="System.Drawing" name="System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
   <data name="btnGuardar.Location" type="System.Drawing.Point, System.Drawing">
     <value>224, 213</value>
   </data>
   <data name="btnGuardar.Size" type="System.Drawing.Size, System.Drawing">
     <value>75, 23</value>
   </data>
-  <assembly alias="mscorlib" name="mscorlib, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <assembly alias="mscorlib" name="mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="btnGuardar.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
   </data>
@@ -540,9 +540,9 @@
   <data name="&gt;&gt;btnCancelar.ZOrder" xml:space="preserve">
     <value>0</value>
   </data>
-  <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+  <data name="$this.Localizable" type="System.Boolean, mscorlib">
     <value>True</value>
-  </metadata>
+  </data>
   <data name="$this.AutoScaleDimensions" type="System.Drawing.SizeF, System.Drawing">
     <value>6, 13</value>
   </data>
@@ -5612,5 +5612,17 @@
   </data>
   <data name="&gt;&gt;$this.Type" xml:space="preserve">
     <value>System.Windows.Forms.Form, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="msgEqual" xml:space="preserve">
+    <value>Algunas teclas están repetidas. Revísalas y vuelve a intentarlo.</value>
+  </data>
+  <data name="msgErrorSaving" xml:space="preserve">
+    <value>Error inesperado al guardar el archivo de configuración. Revisa que tengas lo permisos adecuados y vuelve a intentarlo.</value>
+  </data>
+  <data name="msgSonDefault" xml:space="preserve">
+    <value>No has seleccionado un archivo de sonido. ¿Deseas usar el del sistema?</value>
+  </data>
+  <data name="msgErrorLoadingSound" xml:space="preserve">
+    <value>El archivo especificado no es válido</value>
   </data>
 </root>

--- a/sobreclick.cs
+++ b/sobreclick.cs
@@ -294,7 +294,21 @@ namespace Sobreclick
             {
                 try
                 {
-                    SoundPlayer archivoSon = new SoundPlayer(Conf.dirSonido());
+                    // TODO: Mejorar asignación de archivo de sonido
+                    string ubicacionSonido;
+                    bool sonSistemaPreferido = Conf.sonidoPredeterminado();
+                    switch (sonSistemaPreferido)
+                    {
+                        case true:
+                            // TODO: Parametrizar sonido predeterminado
+                            ubicacionSonido = @"C:\Windows\Media\chord.wav";
+                            break;
+                        case false:
+                        default:
+                            ubicacionSonido = Conf.dirSonido();
+                            break;
+                    }
+                    SoundPlayer archivoSon = new SoundPlayer(ubicacionSonido);
                     archivoSon.Play();
                 }
                 catch (Exception e)


### PR DESCRIPTION
* Detección agregada en form principal, para que pueda comprobar si efectivamente el sonido predeterminado está activo. Antes esto no sucedía, haciendo que la funcionalidad no ande.
* Nueva variable en configuración, que define si ya se cargó la configuración inicial derivada del archivo.
* Corregido selector que establece si el sonido predeterminado del sistema se habilita o no.