### PR TITLE
Ajustar comportamiento de cantidad sin límite al iniciar

### DIFF
--- a/conf.cs
+++ b/conf.cs
@@ -32,6 +32,12 @@ namespace Sobreclick
             bool.TryParse(ConfigurationManager.AppSettings.Get("sonidoPredeterminado"), out valor_predeterminado);
             return valor_predeterminado;
         }
+        public bool sinLimiteCantidadIniciar()
+        {
+            bool valor_predeterminado = true;
+            bool.TryParse(ConfigurationManager.AppSettings.Get("sinLimiteCantidadIniciar"), out valor_predeterminado);
+            return valor_predeterminado;
+        }
         public string dirSonido()
         {
             return ConfigurationManager.AppSettings.Get("dirSonido").Replace("/", "\\");

--- a/sc_config.Designer.cs
+++ b/sc_config.Designer.cs
@@ -38,15 +38,18 @@
             this.label3 = new System.Windows.Forms.Label();
             this.btnRestaurar = new System.Windows.Forms.Button();
             this.panel1 = new System.Windows.Forms.Panel();
-            this.groupBox1 = new System.Windows.Forms.GroupBox();
-            this.groupBox2 = new System.Windows.Forms.GroupBox();
+            this.gbTeclas = new System.Windows.Forms.GroupBox();
+            this.gbSonido = new System.Windows.Forms.GroupBox();
             this.cbSonidosSistema = new System.Windows.Forms.CheckBox();
             this.btnReproducir = new System.Windows.Forms.Button();
             this.tbSoundDir = new System.Windows.Forms.TextBox();
             this.btnExmnr = new System.Windows.Forms.Button();
             this.btnCancelar = new System.Windows.Forms.Button();
-            this.groupBox1.SuspendLayout();
-            this.groupBox2.SuspendLayout();
+            this.gbComp = new System.Windows.Forms.GroupBox();
+            this.cbSinLimiteIniciar = new System.Windows.Forms.CheckBox();
+            this.gbTeclas.SuspendLayout();
+            this.gbSonido.SuspendLayout();
+            this.gbComp.SuspendLayout();
             this.SuspendLayout();
             // 
             // btnGuardar
@@ -108,27 +111,27 @@
             resources.ApplyResources(this.panel1, "panel1");
             this.panel1.Name = "panel1";
             // 
-            // groupBox1
+            // gbTeclas
             // 
-            this.groupBox1.Controls.Add(this.label1);
-            this.groupBox1.Controls.Add(this.tbIni);
-            this.groupBox1.Controls.Add(this.label3);
-            this.groupBox1.Controls.Add(this.label2);
-            this.groupBox1.Controls.Add(this.pbDen);
-            this.groupBox1.Controls.Add(this.tbPR);
-            resources.ApplyResources(this.groupBox1, "groupBox1");
-            this.groupBox1.Name = "groupBox1";
-            this.groupBox1.TabStop = false;
+            this.gbTeclas.Controls.Add(this.label1);
+            this.gbTeclas.Controls.Add(this.tbIni);
+            this.gbTeclas.Controls.Add(this.label3);
+            this.gbTeclas.Controls.Add(this.label2);
+            this.gbTeclas.Controls.Add(this.pbDen);
+            this.gbTeclas.Controls.Add(this.tbPR);
+            resources.ApplyResources(this.gbTeclas, "gbTeclas");
+            this.gbTeclas.Name = "gbTeclas";
+            this.gbTeclas.TabStop = false;
             // 
-            // groupBox2
+            // gbSonido
             // 
-            this.groupBox2.Controls.Add(this.cbSonidosSistema);
-            this.groupBox2.Controls.Add(this.btnReproducir);
-            this.groupBox2.Controls.Add(this.tbSoundDir);
-            this.groupBox2.Controls.Add(this.btnExmnr);
-            resources.ApplyResources(this.groupBox2, "groupBox2");
-            this.groupBox2.Name = "groupBox2";
-            this.groupBox2.TabStop = false;
+            this.gbSonido.Controls.Add(this.cbSonidosSistema);
+            this.gbSonido.Controls.Add(this.btnReproducir);
+            this.gbSonido.Controls.Add(this.tbSoundDir);
+            this.gbSonido.Controls.Add(this.btnExmnr);
+            resources.ApplyResources(this.gbSonido, "gbSonido");
+            this.gbSonido.Name = "gbSonido";
+            this.gbSonido.TabStop = false;
             // 
             // cbSonidosSistema
             // 
@@ -163,26 +166,43 @@
             this.btnCancelar.UseVisualStyleBackColor = true;
             this.btnCancelar.Click += new System.EventHandler(this.btnCancelar_Click);
             // 
+            // gbComp
+            // 
+            this.gbComp.Controls.Add(this.cbSinLimiteIniciar);
+            resources.ApplyResources(this.gbComp, "gbComp");
+            this.gbComp.Name = "gbComp";
+            this.gbComp.TabStop = false;
+            // 
+            // cbSinLimiteIniciar
+            // 
+            resources.ApplyResources(this.cbSinLimiteIniciar, "cbSinLimiteIniciar");
+            this.cbSinLimiteIniciar.Name = "cbSinLimiteIniciar";
+            this.cbSinLimiteIniciar.UseVisualStyleBackColor = true;
+            this.cbSinLimiteIniciar.CheckedChanged += new System.EventHandler(this.checkBox1_CheckedChanged_1);
+            // 
             // sc_config
             // 
             resources.ApplyResources(this, "$this");
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.Controls.Add(this.gbComp);
             this.Controls.Add(this.btnCancelar);
-            this.Controls.Add(this.groupBox2);
+            this.Controls.Add(this.gbSonido);
             this.Controls.Add(this.panel1);
             this.Controls.Add(this.btnRestaurar);
             this.Controls.Add(this.btnGuardar);
-            this.Controls.Add(this.groupBox1);
+            this.Controls.Add(this.gbTeclas);
             this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedDialog;
             this.MaximizeBox = false;
             this.MinimizeBox = false;
             this.Name = "sc_config";
             this.FormClosing += new System.Windows.Forms.FormClosingEventHandler(this.sc_config_FormClosing);
             this.Load += new System.EventHandler(this.sc_config_Load);
-            this.groupBox1.ResumeLayout(false);
-            this.groupBox1.PerformLayout();
-            this.groupBox2.ResumeLayout(false);
-            this.groupBox2.PerformLayout();
+            this.gbTeclas.ResumeLayout(false);
+            this.gbTeclas.PerformLayout();
+            this.gbSonido.ResumeLayout(false);
+            this.gbSonido.PerformLayout();
+            this.gbComp.ResumeLayout(false);
+            this.gbComp.PerformLayout();
             this.ResumeLayout(false);
 
         }
@@ -198,12 +218,14 @@
         private System.Windows.Forms.Label label3;
         private System.Windows.Forms.Button btnRestaurar;
         private System.Windows.Forms.Panel panel1;
-        private System.Windows.Forms.GroupBox groupBox1;
-        private System.Windows.Forms.GroupBox groupBox2;
+        private System.Windows.Forms.GroupBox gbTeclas;
+        private System.Windows.Forms.GroupBox gbSonido;
         private System.Windows.Forms.CheckBox cbSonidosSistema;
         private System.Windows.Forms.Button btnReproducir;
         private System.Windows.Forms.TextBox tbSoundDir;
         private System.Windows.Forms.Button btnExmnr;
         private System.Windows.Forms.Button btnCancelar;
+        private System.Windows.Forms.GroupBox gbComp;
+        private System.Windows.Forms.CheckBox cbSinLimiteIniciar;
     }
 }

--- a/sc_config.cs
+++ b/sc_config.cs
@@ -18,6 +18,7 @@ namespace Sobreclick
         public static TypeConverter conversor = TypeDescriptor.GetConverter(typeof(Keys));
         SoundPlayer testingSound;
         bool confInicialComprobada = false;
+        bool confSinLimiteIniciar = false;
 
         ResourceManager rm = new ResourceManager(typeof(sc_config));
 
@@ -29,6 +30,7 @@ namespace Sobreclick
         // Sonidos
         public static string sonConfDir = Conf.dirSonido();
         public static bool sonSistemaPreferido = Conf.sonidoPredeterminado();
+        public static bool sonSinLimiteIniciar = Conf.sinLimiteCantidadIniciar();
 
         public sc_config()
         {
@@ -111,6 +113,18 @@ namespace Sobreclick
                         sonSistemaPreferido = false;
                         break;
                 }
+                switch (cbSinLimiteIniciar.Checked)
+                {
+                    case true:
+                        sonSinLimiteIniciar = true;
+                        break;
+                    case false:
+                    default:
+                        sonSinLimiteIniciar = false;
+                        break;
+                }
+                strings.actualizarAjusteBooleano("sonidoPredeterminado", sonSistemaPreferido);
+                strings.actualizarAjusteBooleano("sinLimiteCantidadIniciar", sonSinLimiteIniciar);
                 strings.actualizarSonidoPredeterminado(sonSistemaPreferido);
                 this.Close();
             }
@@ -159,7 +173,8 @@ namespace Sobreclick
                     btnExmnr.Enabled = true;
                     cbSonidosSistema.Checked = false;
                     break;
-            } 
+            }
+            cbSinLimiteIniciar.Checked = sonSinLimiteIniciar;
         }
 
         private void turnarConfigSonido()
@@ -278,6 +293,20 @@ namespace Sobreclick
         private void btnCancelar_Click(object sender, EventArgs e)
         {
             Close();
+        }
+
+        private void checkBox1_CheckedChanged_1(object sender, EventArgs e)
+        {
+            switch (confSinLimiteIniciar)
+            {
+                case true:
+                    confSinLimiteIniciar = true;
+                    break;
+                case false:
+                default:
+                    confSinLimiteIniciar = false;
+                    break;
+            }
         }
     }
 }

--- a/sc_config.en.resx
+++ b/sc_config.en.resx
@@ -142,11 +142,8 @@
   <data name="btnRestaurar.Text" xml:space="preserve">
     <value>&amp;Restore</value>
   </data>
-  <data name="groupBox1.Text" xml:space="preserve">
-    <value>Keys</value>
-  </data>
-  <data name="checkBox1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>117, 17</value>
+  <data name="cbSonidosSistema.Size" type="System.Drawing.Size, System.Drawing">
+    <value>147, 17</value>
   </data>
   <data name="cbSonidosSistema.Text" xml:space="preserve">
     <value>&amp;Use system default sound</value>
@@ -157,8 +154,17 @@
   <data name="btnExmnr.Text" xml:space="preserve">
     <value>&amp;Browse</value>
   </data>
-  <data name="groupBox2.Text" xml:space="preserve">
-    <value>Sound</value>
+  <data name="btnCancelar.Text" xml:space="preserve">
+    <value>&amp;Cancel</value>
+  </data>
+  <data name="gbComp.Text" xml:space="preserve">
+    <value>Behavior</value>
+  </data>
+  <data name="cbSinLimiteIniciar.Size" type="System.Drawing.Size, System.Drawing">
+    <value>145, 17</value>
+  </data>
+  <data name="cbSinLimiteIniciar.Text" xml:space="preserve">
+    <value>U&amp;nlimited amount on start</value>
   </data>
   <data name="$this.Icon" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
@@ -5218,16 +5224,16 @@
   <data name="$this.Text" xml:space="preserve">
     <value>Settings</value>
   </data>
-  <data name="msgEqual" xml:space="preserve">
+	<data name="msgEqual" xml:space="preserve">
     <value>Some keys are repeated. Check them and try again.</value>
   </data>
-  <data name="msgErrorSaving" xml:space="preserve">
+	<data name="msgErrorSaving" xml:space="preserve">
     <value>Unexpected error when saving the configuration file. Check that you have enougth permissions to do that and try again.</value>
   </data>
-  <data name="msgSonDefault" xml:space="preserve">
+	<data name="msgSonDefault" xml:space="preserve">
     <value>You didn't selected a sound file. Do you wanna to use the system default one?</value>
   </data>
-  <data name="msgErrorLoadingSound" xml:space="preserve">
+	<data name="msgErrorLoadingSound" xml:space="preserve">
     <value>The file specified is invalid</value>
   </data>
 </root>

--- a/sc_config.resx
+++ b/sc_config.resx
@@ -112,23 +112,23 @@
     <value>2.0</value>
   </resheader>
   <resheader name="reader">
-    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <resheader name="writer">
-    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="btnGuardar.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Bottom, Right</value>
   </data>
-  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+  <assembly alias="System.Drawing" name="System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
   <data name="btnGuardar.Location" type="System.Drawing.Point, System.Drawing">
-    <value>224, 213</value>
+    <value>224, 221</value>
   </data>
   <data name="btnGuardar.Size" type="System.Drawing.Size, System.Drawing">
     <value>75, 23</value>
   </data>
-  <assembly alias="mscorlib" name="mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <assembly alias="mscorlib" name="mscorlib, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="btnGuardar.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
   </data>
@@ -145,7 +145,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;btnGuardar.ZOrder" xml:space="preserve">
-    <value>4</value>
+    <value>5</value>
   </data>
   <data name="tbIni.Location" type="System.Drawing.Point, System.Drawing">
     <value>98, 33</value>
@@ -166,7 +166,7 @@
     <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;tbIni.Parent" xml:space="preserve">
-    <value>groupBox1</value>
+    <value>gbTeclas</value>
   </data>
   <data name="&gt;&gt;tbIni.ZOrder" xml:space="preserve">
     <value>1</value>
@@ -193,7 +193,7 @@
     <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;tbPR.Parent" xml:space="preserve">
-    <value>groupBox1</value>
+    <value>gbTeclas</value>
   </data>
   <data name="&gt;&gt;tbPR.ZOrder" xml:space="preserve">
     <value>5</value>
@@ -220,7 +220,7 @@
     <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;pbDen.Parent" xml:space="preserve">
-    <value>groupBox1</value>
+    <value>gbTeclas</value>
   </data>
   <data name="&gt;&gt;pbDen.ZOrder" xml:space="preserve">
     <value>4</value>
@@ -247,7 +247,7 @@
     <value>System.Windows.Forms.Label, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;label1.Parent" xml:space="preserve">
-    <value>groupBox1</value>
+    <value>gbTeclas</value>
   </data>
   <data name="&gt;&gt;label1.ZOrder" xml:space="preserve">
     <value>0</value>
@@ -277,7 +277,7 @@
     <value>System.Windows.Forms.Label, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;label2.Parent" xml:space="preserve">
-    <value>groupBox1</value>
+    <value>gbTeclas</value>
   </data>
   <data name="&gt;&gt;label2.ZOrder" xml:space="preserve">
     <value>3</value>
@@ -307,7 +307,7 @@
     <value>System.Windows.Forms.Label, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;label3.Parent" xml:space="preserve">
-    <value>groupBox1</value>
+    <value>gbTeclas</value>
   </data>
   <data name="&gt;&gt;label3.ZOrder" xml:space="preserve">
     <value>2</value>
@@ -319,7 +319,7 @@
     <value>False</value>
   </data>
   <data name="btnRestaurar.Location" type="System.Drawing.Point, System.Drawing">
-    <value>15, 213</value>
+    <value>15, 221</value>
   </data>
   <data name="btnRestaurar.Size" type="System.Drawing.Size, System.Drawing">
     <value>75, 23</value>
@@ -340,7 +340,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;btnRestaurar.ZOrder" xml:space="preserve">
-    <value>3</value>
+    <value>4</value>
   </data>
   <data name="panel1.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
     <value>Top</value>
@@ -364,31 +364,31 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;panel1.ZOrder" xml:space="preserve">
-    <value>2</value>
+    <value>3</value>
   </data>
-  <data name="groupBox1.Location" type="System.Drawing.Point, System.Drawing">
+  <data name="gbTeclas.Location" type="System.Drawing.Point, System.Drawing">
     <value>12, 30</value>
   </data>
-  <data name="groupBox1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>142, 151</value>
+  <data name="gbTeclas.Size" type="System.Drawing.Size, System.Drawing">
+    <value>142, 167</value>
   </data>
-  <data name="groupBox1.TabIndex" type="System.Int32, mscorlib">
+  <data name="gbTeclas.TabIndex" type="System.Int32, mscorlib">
     <value>14</value>
   </data>
-  <data name="groupBox1.Text" xml:space="preserve">
+  <data name="gbTeclas.Text" xml:space="preserve">
     <value>Teclas</value>
   </data>
-  <data name="&gt;&gt;groupBox1.Name" xml:space="preserve">
-    <value>groupBox1</value>
+  <data name="&gt;&gt;gbTeclas.Name" xml:space="preserve">
+    <value>gbTeclas</value>
   </data>
-  <data name="&gt;&gt;groupBox1.Type" xml:space="preserve">
+  <data name="&gt;&gt;gbTeclas.Type" xml:space="preserve">
     <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;groupBox1.Parent" xml:space="preserve">
+  <data name="&gt;&gt;gbTeclas.Parent" xml:space="preserve">
     <value>$this</value>
   </data>
-  <data name="&gt;&gt;groupBox1.ZOrder" xml:space="preserve">
-    <value>5</value>
+  <data name="&gt;&gt;gbTeclas.ZOrder" xml:space="preserve">
+    <value>6</value>
   </data>
   <data name="cbSonidosSistema.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -397,13 +397,13 @@
     <value>9, 25</value>
   </data>
   <data name="cbSonidosSistema.Size" type="System.Drawing.Size, System.Drawing">
-    <value>142, 17</value>
+    <value>158, 17</value>
   </data>
   <data name="cbSonidosSistema.TabIndex" type="System.Int32, mscorlib">
     <value>3</value>
   </data>
   <data name="cbSonidosSistema.Text" xml:space="preserve">
-    <value>Usar sonidos del sistema</value>
+    <value>Usar sonido predeterminado</value>
   </data>
   <data name="&gt;&gt;cbSonidosSistema.Name" xml:space="preserve">
     <value>cbSonidosSistema</value>
@@ -412,7 +412,7 @@
     <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;cbSonidosSistema.Parent" xml:space="preserve">
-    <value>groupBox2</value>
+    <value>gbSonido</value>
   </data>
   <data name="&gt;&gt;cbSonidosSistema.ZOrder" xml:space="preserve">
     <value>0</value>
@@ -439,7 +439,7 @@
     <value>System.Windows.Forms.Button, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;btnReproducir.Parent" xml:space="preserve">
-    <value>groupBox2</value>
+    <value>gbSonido</value>
   </data>
   <data name="&gt;&gt;btnReproducir.ZOrder" xml:space="preserve">
     <value>1</value>
@@ -460,7 +460,7 @@
     <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;tbSoundDir.Parent" xml:space="preserve">
-    <value>groupBox2</value>
+    <value>gbSonido</value>
   </data>
   <data name="&gt;&gt;tbSoundDir.ZOrder" xml:space="preserve">
     <value>2</value>
@@ -484,40 +484,43 @@
     <value>System.Windows.Forms.Button, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;btnExmnr.Parent" xml:space="preserve">
-    <value>groupBox2</value>
+    <value>gbSonido</value>
   </data>
   <data name="&gt;&gt;btnExmnr.ZOrder" xml:space="preserve">
     <value>3</value>
   </data>
-  <data name="groupBox2.Location" type="System.Drawing.Point, System.Drawing">
+  <data name="gbSonido.Location" type="System.Drawing.Point, System.Drawing">
     <value>160, 30</value>
   </data>
-  <data name="groupBox2.Size" type="System.Drawing.Size, System.Drawing">
+  <data name="gbSonido.Size" type="System.Drawing.Size, System.Drawing">
     <value>220, 108</value>
   </data>
-  <data name="groupBox2.TabIndex" type="System.Int32, mscorlib">
+  <data name="gbSonido.TabIndex" type="System.Int32, mscorlib">
     <value>15</value>
   </data>
-  <data name="groupBox2.Text" xml:space="preserve">
+  <data name="gbSonido.Text" xml:space="preserve">
     <value>Sonido</value>
   </data>
-  <data name="&gt;&gt;groupBox2.Name" xml:space="preserve">
-    <value>groupBox2</value>
+  <data name="&gt;&gt;gbSonido.Name" xml:space="preserve">
+    <value>gbSonido</value>
   </data>
-  <data name="&gt;&gt;groupBox2.Type" xml:space="preserve">
+  <data name="&gt;&gt;gbSonido.Type" xml:space="preserve">
     <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;groupBox2.Parent" xml:space="preserve">
+  <data name="&gt;&gt;gbSonido.Parent" xml:space="preserve">
     <value>$this</value>
   </data>
-  <data name="&gt;&gt;groupBox2.ZOrder" xml:space="preserve">
-    <value>1</value>
+  <data name="&gt;&gt;gbSonido.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="btnCancelar.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Bottom, Right</value>
   </data>
   <data name="btnCancelar.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
   </data>
   <data name="btnCancelar.Location" type="System.Drawing.Point, System.Drawing">
-    <value>301, 213</value>
+    <value>301, 221</value>
   </data>
   <data name="btnCancelar.Size" type="System.Drawing.Size, System.Drawing">
     <value>75, 23</value>
@@ -538,16 +541,67 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;btnCancelar.ZOrder" xml:space="preserve">
-    <value>0</value>
+    <value>1</value>
   </data>
-  <data name="$this.Localizable" type="System.Boolean, mscorlib">
+  <data name="cbSinLimiteIniciar.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
+  <data name="cbSinLimiteIniciar.Location" type="System.Drawing.Point, System.Drawing">
+    <value>9, 19</value>
+  </data>
+  <data name="cbSinLimiteIniciar.Size" type="System.Drawing.Size, System.Drawing">
+    <value>149, 17</value>
+  </data>
+  <data name="cbSinLimiteIniciar.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="cbSinLimiteIniciar.Text" xml:space="preserve">
+    <value>Cantidad ilimitada al iniciar</value>
+  </data>
+  <data name="&gt;&gt;cbSinLimiteIniciar.Name" xml:space="preserve">
+    <value>cbSinLimiteIniciar</value>
+  </data>
+  <data name="&gt;&gt;cbSinLimiteIniciar.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;cbSinLimiteIniciar.Parent" xml:space="preserve">
+    <value>gbComp</value>
+  </data>
+  <data name="&gt;&gt;cbSinLimiteIniciar.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="gbComp.Location" type="System.Drawing.Point, System.Drawing">
+    <value>160, 144</value>
+  </data>
+  <data name="gbComp.Size" type="System.Drawing.Size, System.Drawing">
+    <value>214, 53</value>
+  </data>
+  <data name="gbComp.TabIndex" type="System.Int32, mscorlib">
+    <value>16</value>
+  </data>
+  <data name="gbComp.Text" xml:space="preserve">
+    <value>Comportamiento</value>
+  </data>
+  <data name="&gt;&gt;gbComp.Name" xml:space="preserve">
+    <value>gbComp</value>
+  </data>
+  <data name="&gt;&gt;gbComp.Type" xml:space="preserve">
+    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;gbComp.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;gbComp.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
   <data name="$this.AutoScaleDimensions" type="System.Drawing.SizeF, System.Drawing">
     <value>6, 13</value>
   </data>
   <data name="$this.ClientSize" type="System.Drawing.Size, System.Drawing">
-    <value>392, 248</value>
+    <value>392, 256</value>
   </data>
   <data name="$this.Icon" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
@@ -5613,16 +5667,16 @@
   <data name="&gt;&gt;$this.Type" xml:space="preserve">
     <value>System.Windows.Forms.Form, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="msgEqual" xml:space="preserve">
+	<data name="msgEqual" xml:space="preserve">
     <value>Algunas teclas están repetidas. Revísalas y vuelve a intentarlo.</value>
   </data>
-  <data name="msgErrorSaving" xml:space="preserve">
+	<data name="msgErrorSaving" xml:space="preserve">
     <value>Error inesperado al guardar el archivo de configuración. Revisa que tengas lo permisos adecuados y vuelve a intentarlo.</value>
   </data>
-  <data name="msgSonDefault" xml:space="preserve">
+	<data name="msgSonDefault" xml:space="preserve">
     <value>No has seleccionado un archivo de sonido. ¿Deseas usar el del sistema?</value>
   </data>
-  <data name="msgErrorLoadingSound" xml:space="preserve">
+	<data name="msgErrorLoadingSound" xml:space="preserve">
     <value>El archivo especificado no es válido</value>
   </data>
 </root>

--- a/sobreclick.cs
+++ b/sobreclick.cs
@@ -571,10 +571,15 @@ namespace Sobreclick
         private void sobreclick_Load(object sender, EventArgs e)
         {
             clickTimes = Convert.ToInt32(numericUpDown1.Value);
+            verificarConf();
             actualizarDirSon();
             actualizarTeclas();
         }
 
+        private void verificarConf()
+        {
+            cbSinLimite.Checked = Conf.sinLimiteCantidadIniciar();
+        }
         private void visitarRepositorioToolStripMenuItem_Click(object sender, EventArgs e)
         {
             System.Diagnostics.Process.Start(strings.scRepositorio);

--- a/strings.cs
+++ b/strings.cs
@@ -65,7 +65,21 @@ namespace Sobreclick
             configSave.Save(ConfigurationSaveMode.Modified);
             ConfigurationManager.RefreshSection(configSave.AppSettings.SectionInformation.Name);
         }
-
+        public static void actualizarAjusteBooleano(string ajuste, bool valor)
+        {
+            Configuration configSave = ConfigurationManager.OpenExeConfiguration(ConfigurationUserLevel.None);
+            switch (valor)
+            {
+                case true:
+                    configSave.AppSettings.Settings[ajuste].Value = "true";
+                    break;
+                case false:
+                    configSave.AppSettings.Settings[ajuste].Value = "false";
+                    break;
+            }
+            configSave.Save(ConfigurationSaveMode.Modified);
+            ConfigurationManager.RefreshSection(configSave.AppSettings.SectionInformation.Name);
+        }
         public static void actualizarSonidoPredeterminado(bool valor)
         {
             Configuration configSave = ConfigurationManager.OpenExeConfiguration(ConfigurationUserLevel.None);


### PR DESCRIPTION
* Se agrega la nueva opción en el form de configuración que permite activar o desactivar la función que hace ilimitada la cantidad de clics, al inicio del programa.
* Creación de variables que toman el novel parámetro en el archivo de configuración.
* Nueva función que permite alternar configuraciones del programa que tomen valores booleanos.
* Renombre de elementos del form correspondientes a los combobox.
* Opción de la configuración "Usar sonidos del sistema" pasa a llamarse "Usar sonido predeterminado"