### PR TITLE
Definir variables configurables por defecto

### DIFF
--- a/conf.cs
+++ b/conf.cs
@@ -12,12 +12,12 @@ namespace Sobreclick
     class conf
     {
         // Valores predefinidos, según cada parámetro configurable del programa
-        string tecla_iniciar = "F6";
-        string tecla_pausar_reanudar = "F7";
-        string tecla_detener = "F8";
-        string dir_sonido = "C:\\Windows\\Media\\notify.wav";
-        bool sonido_predeterminado = false;
-        bool sin_limite_cantidad_iniciar = true;
+        public Keys tecla_iniciar = Keys.F6;
+        public Keys tecla_pausar_reanudar = Keys.F7;
+        public Keys tecla_detener = Keys.F8;
+        public string dir_sonido = "C:\\Windows\\Media\\notify.wav";
+        public bool sonido_predeterminado = false;
+        public bool sin_limite_cantidad_iniciar = true;
 
         public conf()
         {

--- a/sc_config.Designer.cs
+++ b/sc_config.Designer.cs
@@ -47,6 +47,7 @@
             this.btnCancelar = new System.Windows.Forms.Button();
             this.gbComp = new System.Windows.Forms.GroupBox();
             this.cbSinLimiteIniciar = new System.Windows.Forms.CheckBox();
+            this.btnValoresPredeterminados = new System.Windows.Forms.Button();
             this.gbTeclas.SuspendLayout();
             this.gbSonido.SuspendLayout();
             this.gbComp.SuspendLayout();
@@ -103,7 +104,7 @@
             resources.ApplyResources(this.btnRestaurar, "btnRestaurar");
             this.btnRestaurar.Name = "btnRestaurar";
             this.btnRestaurar.UseVisualStyleBackColor = true;
-            this.btnRestaurar.Click += new System.EventHandler(this.button2_Click);
+            this.btnRestaurar.Click += new System.EventHandler(this.btnRestaurar_Click);
             // 
             // panel1
             // 
@@ -180,10 +181,18 @@
             this.cbSinLimiteIniciar.UseVisualStyleBackColor = true;
             this.cbSinLimiteIniciar.CheckedChanged += new System.EventHandler(this.checkBox1_CheckedChanged_1);
             // 
+            // btnValoresPredeterminados
+            // 
+            resources.ApplyResources(this.btnValoresPredeterminados, "btnValoresPredeterminados");
+            this.btnValoresPredeterminados.Name = "btnValoresPredeterminados";
+            this.btnValoresPredeterminados.UseVisualStyleBackColor = true;
+            this.btnValoresPredeterminados.Click += new System.EventHandler(this.btnValoresPredeterminados_Click);
+            // 
             // sc_config
             // 
             resources.ApplyResources(this, "$this");
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.Controls.Add(this.btnValoresPredeterminados);
             this.Controls.Add(this.gbComp);
             this.Controls.Add(this.btnCancelar);
             this.Controls.Add(this.gbSonido);
@@ -227,5 +236,6 @@
         private System.Windows.Forms.Button btnCancelar;
         private System.Windows.Forms.GroupBox gbComp;
         private System.Windows.Forms.CheckBox cbSinLimiteIniciar;
+        private System.Windows.Forms.Button btnValoresPredeterminados;
     }
 }

--- a/sc_config.cs
+++ b/sc_config.cs
@@ -95,6 +95,24 @@ namespace Sobreclick
             }
         }
 
+        private void reestablecerCambiosConf()
+        {
+            // Actualizar datos de configuración
+            strings.actualizarTecla(1, Conf.tecla_iniciar);
+            strings.actualizarTecla(2, Conf.tecla_pausar_reanudar);
+            strings.actualizarTecla(3, Conf.tecla_detener);
+            strings.actualizarArchivoSon(Conf.dir_sonido);
+            strings.actualizarAjusteBooleano("sonidoPredeterminado", Conf.sonido_predeterminado);
+            strings.actualizarAjusteBooleano("sinLimiteCantidadIniciar", Conf.sin_limite_cantidad_iniciar);
+
+            sonConfDir = Conf.dirSonido();
+            sonSistemaPreferido = Conf.sonidoPredeterminado();
+            sonSinLimiteIniciar = Conf.sinLimiteCantidadIniciar();
+
+            // Recambiar en form
+            btnRestaurar.Enabled = false;
+            cargarConf();
+        }
         private void guardarCambiosConf()
         {
             try
@@ -136,11 +154,17 @@ namespace Sobreclick
 
         private void sc_config_Load(object sender, EventArgs e)
         {
+            // Cargar configuración
+            cargarConf();
+        }
+
+        private void cargarConf()
+        {
             tbIni.Clear();
             tbPR.Clear();
             pbDen.Clear();
             tbSoundDir.Clear();
-            
+
             // Cargar variables de teclas
             iniT = (Keys)conversor.ConvertFromString(Conf.teclaIniciar());
             pauT = (Keys)conversor.ConvertFromString(Conf.teclaPausarReanudar());
@@ -157,7 +181,6 @@ namespace Sobreclick
 
             confInicialComprobada = true;
         }
-
         private void verificarConfSonido()
         {
             switch (sonSistemaPreferido)
@@ -217,7 +240,7 @@ namespace Sobreclick
                 }
             }
         }
-        private void button2_Click(object sender, EventArgs e)
+        private void btnRestaurar_Click(object sender, EventArgs e)
         {
             iniT = strings.iniT;
             pauT = strings.pauT;
@@ -232,7 +255,6 @@ namespace Sobreclick
             tbSoundDir.AppendText(sonConfDir);
             btnRestaurar.Enabled = false;
         }
-
         private void checkBox1_CheckedChanged(object sender, EventArgs e)
         {
             switch (confInicialComprobada)
@@ -287,7 +309,10 @@ namespace Sobreclick
 
         private void tbSoundDir_TextChanged(object sender, EventArgs e)
         {
-            btnRestaurar.Enabled = true;
+            if (confInicialComprobada == true)
+            {
+                btnRestaurar.Enabled = true;
+            }
         }
 
         private void btnCancelar_Click(object sender, EventArgs e)
@@ -305,6 +330,18 @@ namespace Sobreclick
                 case false:
                 default:
                     confSinLimiteIniciar = false;
+                    break;
+            }
+        }
+
+        private void btnValoresPredeterminados_Click(object sender, EventArgs e)
+        {
+            DialogResult confirmValoresPredeterminados = MessageBox.Show(rm.GetString("msgValoresPredeterminados"), "Error", MessageBoxButtons.YesNo, MessageBoxIcon.Question);
+            switch (confirmValoresPredeterminados)
+            {
+                case DialogResult.Yes:
+                    confInicialComprobada = false; // TODO: Buscar una manera de emprolijar la detección
+                    reestablecerCambiosConf();
                     break;
             }
         }

--- a/sc_config.en.resx
+++ b/sc_config.en.resx
@@ -112,15 +112,15 @@
     <value>2.0</value>
   </resheader>
   <resheader name="reader">
-    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <resheader name="writer">
-    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="btnGuardar.Text" xml:space="preserve">
     <value>&amp;Save</value>
   </data>
-  <assembly alias="System.Drawing" name="System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
   <data name="label1.Size" type="System.Drawing.Size, System.Drawing">
     <value>29, 13</value>
   </data>
@@ -154,17 +154,23 @@
   <data name="btnExmnr.Text" xml:space="preserve">
     <value>&amp;Browse</value>
   </data>
+  <data name="gbSonido.Text" xml:space="preserve">
+    <value>Sound</value>
+  </data>
   <data name="btnCancelar.Text" xml:space="preserve">
     <value>&amp;Cancel</value>
-  </data>
-  <data name="gbComp.Text" xml:space="preserve">
-    <value>Behavior</value>
   </data>
   <data name="cbSinLimiteIniciar.Size" type="System.Drawing.Size, System.Drawing">
     <value>145, 17</value>
   </data>
   <data name="cbSinLimiteIniciar.Text" xml:space="preserve">
     <value>U&amp;nlimited amount on start</value>
+  </data>
+  <data name="gbComp.Text" xml:space="preserve">
+    <value>Behavior</value>
+  </data>
+  <data name="btnValoresPredeterminados.Text" xml:space="preserve">
+    <value>&amp;Default values</value>
   </data>
   <data name="$this.Icon" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
@@ -5224,16 +5230,19 @@
   <data name="$this.Text" xml:space="preserve">
     <value>Settings</value>
   </data>
-	<data name="msgEqual" xml:space="preserve">
+  <data name="msgEqual" xml:space="preserve">
     <value>Some keys are repeated. Check them and try again.</value>
   </data>
-	<data name="msgErrorSaving" xml:space="preserve">
+  <data name="msgErrorSaving" xml:space="preserve">
     <value>Unexpected error when saving the configuration file. Check that you have enougth permissions to do that and try again.</value>
   </data>
-	<data name="msgSonDefault" xml:space="preserve">
+  <data name="msgSonDefault" xml:space="preserve">
     <value>You didn't selected a sound file. Do you wanna to use the system default one?</value>
   </data>
-	<data name="msgErrorLoadingSound" xml:space="preserve">
+  <data name="msgErrorLoadingSound" xml:space="preserve">
     <value>The file specified is invalid</value>
+  </data>
+  <data name="msgValoresPredeterminados" xml:space="preserve">
+    <value>This will restore all values to factory defaults. Are you sure?</value>
   </data>
 </root>

--- a/sc_config.resx
+++ b/sc_config.resx
@@ -145,7 +145,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;btnGuardar.ZOrder" xml:space="preserve">
-    <value>5</value>
+    <value>6</value>
   </data>
   <data name="tbIni.Location" type="System.Drawing.Point, System.Drawing">
     <value>98, 33</value>
@@ -175,7 +175,7 @@
     <value>Top</value>
   </data>
   <data name="tbPR.Location" type="System.Drawing.Point, System.Drawing">
-    <value>98, 73</value>
+    <value>98, 61</value>
   </data>
   <data name="tbPR.Size" type="System.Drawing.Size, System.Drawing">
     <value>38, 20</value>
@@ -202,7 +202,7 @@
     <value>Top, Right</value>
   </data>
   <data name="pbDen.Location" type="System.Drawing.Point, System.Drawing">
-    <value>98, 115</value>
+    <value>98, 92</value>
   </data>
   <data name="pbDen.Size" type="System.Drawing.Size, System.Drawing">
     <value>38, 20</value>
@@ -259,7 +259,7 @@
     <value>True</value>
   </data>
   <data name="label2.Location" type="System.Drawing.Point, System.Drawing">
-    <value>6, 76</value>
+    <value>6, 64</value>
   </data>
   <data name="label2.Size" type="System.Drawing.Size, System.Drawing">
     <value>92, 13</value>
@@ -289,7 +289,7 @@
     <value>True</value>
   </data>
   <data name="label3.Location" type="System.Drawing.Point, System.Drawing">
-    <value>6, 118</value>
+    <value>6, 95</value>
   </data>
   <data name="label3.Size" type="System.Drawing.Size, System.Drawing">
     <value>45, 13</value>
@@ -319,7 +319,7 @@
     <value>False</value>
   </data>
   <data name="btnRestaurar.Location" type="System.Drawing.Point, System.Drawing">
-    <value>15, 221</value>
+    <value>12, 174</value>
   </data>
   <data name="btnRestaurar.Size" type="System.Drawing.Size, System.Drawing">
     <value>75, 23</value>
@@ -328,7 +328,7 @@
     <value>8</value>
   </data>
   <data name="btnRestaurar.Text" xml:space="preserve">
-    <value>&amp;Restaurar</value>
+    <value>&amp;Revertir</value>
   </data>
   <data name="&gt;&gt;btnRestaurar.Name" xml:space="preserve">
     <value>btnRestaurar</value>
@@ -340,7 +340,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;btnRestaurar.ZOrder" xml:space="preserve">
-    <value>4</value>
+    <value>5</value>
   </data>
   <data name="panel1.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
     <value>Top</value>
@@ -364,13 +364,13 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;panel1.ZOrder" xml:space="preserve">
-    <value>3</value>
+    <value>4</value>
   </data>
   <data name="gbTeclas.Location" type="System.Drawing.Point, System.Drawing">
     <value>12, 30</value>
   </data>
   <data name="gbTeclas.Size" type="System.Drawing.Size, System.Drawing">
-    <value>142, 167</value>
+    <value>142, 138</value>
   </data>
   <data name="gbTeclas.TabIndex" type="System.Int32, mscorlib">
     <value>14</value>
@@ -388,7 +388,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;gbTeclas.ZOrder" xml:space="preserve">
-    <value>6</value>
+    <value>7</value>
   </data>
   <data name="cbSonidosSistema.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -511,7 +511,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;gbSonido.ZOrder" xml:space="preserve">
-    <value>2</value>
+    <value>3</value>
   </data>
   <data name="btnCancelar.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Bottom, Right</value>
@@ -541,7 +541,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;btnCancelar.ZOrder" xml:space="preserve">
-    <value>1</value>
+    <value>2</value>
   </data>
   <data name="cbSinLimiteIniciar.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -592,6 +592,30 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;gbComp.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="btnValoresPredeterminados.Location" type="System.Drawing.Point, System.Drawing">
+    <value>12, 221</value>
+  </data>
+  <data name="btnValoresPredeterminados.Size" type="System.Drawing.Size, System.Drawing">
+    <value>142, 23</value>
+  </data>
+  <data name="btnValoresPredeterminados.TabIndex" type="System.Int32, mscorlib">
+    <value>17</value>
+  </data>
+  <data name="btnValoresPredeterminados.Text" xml:space="preserve">
+    <value>&amp;Valores predeterminados</value>
+  </data>
+  <data name="&gt;&gt;btnValoresPredeterminados.Name" xml:space="preserve">
+    <value>btnValoresPredeterminados</value>
+  </data>
+  <data name="&gt;&gt;btnValoresPredeterminados.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;btnValoresPredeterminados.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;btnValoresPredeterminados.ZOrder" xml:space="preserve">
     <value>0</value>
   </data>
   <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
@@ -5678,5 +5702,8 @@
   </data>
 	<data name="msgErrorLoadingSound" xml:space="preserve">
     <value>El archivo especificado no es válido</value>
+  </data>
+	<data name="msgValoresPredeterminados" xml:space="preserve">
+    <value>Esto reestablecerá la configuración a sus valores predeterminados de fábrica. ¿Estás seguro?</value>
   </data>
 </root>


### PR DESCRIPTION
* Nuevo mensaje que consulta al usuario si está seguro de reestablecer la configuración a sus valores predeterminados.
* Nueva función en el form de configuración, que permite reestablecer los cambios en la configuración.
* Al cargar el anterior form, se llamará a un método que realizará el anterior procedimiento por su cuenta, sabiendo que este se utilizará para la implementación.
* Variables de teclas predeterminadas readaptadas a su tipo correspondiente (Keys), en lugar de cadenas de texto.
* Nuevo botón en la ventana de ajustes que apunta a la nueva opción.